### PR TITLE
Add sqlalchemy uri for our app/db config

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,13 @@ from social_flask.routes import social_auth
 from social_flask_sqlalchemy.models import init_social, PSABase
 from flask_cors import CORS
 
+from config.flask import Development
+
+
+SQLALCHEMY_DATABASE_URI = Development.SQLALCHEMY_DATABASE_URI
+
 app = Flask(__name__, template_folder='static/templates')
+app.config.from_object(__name__)  # add capitalized variables above to config
 app.register_blueprint(social_auth)
 cors = CORS(app, origins=[re.compile('https?:\/\/localhost:[0-9]+')])
 


### PR DESCRIPTION
We need the db uri when we're working with the db locally. Otherwise `from app import db` will return a db engine at some default location.

Leaving it as the development uri for now. When we start hosting this somewhere, we'll need to use the production db uri, in which case we can start getting fancier with our settings files.