### PR TITLE
Add /api/messages endpoint

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -4,7 +4,7 @@ from app import app, db
 from app.models import Token
 import types
 
-def api(f):
+def login_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         authorization = request.headers.get('Authorization')

--- a/app/lib/util.py
+++ b/app/lib/util.py
@@ -1,0 +1,24 @@
+import pytz
+from datetime import datetime
+
+
+def convert_to_timestamp(date):
+    """
+    params date [String] - mm/dd/yy
+    returns [String] - Unix time in milliseconds
+    """
+    dt = datetime.strptime(date, "%m/%d/%y")
+
+    epoch = datetime.utcfromtimestamp(0)
+    ms_from_epoch = (dt - epoch).total_seconds() * 1000
+
+    return str(long(ms_from_epoch))
+
+def convert_unix_to_readable(timestamp):
+    """
+    params timestamp [String] number of milliseconds from epoch
+    Returns [String] - date in platform's local timestamp
+    """
+    seconds = int(timestamp) / 1000
+    utc = pytz.timezone('UTC')
+    return datetime.fromtimestamp(seconds, utc).strftime('%m/%d/%y %H:%M')

--- a/app/models.py
+++ b/app/models.py
@@ -1,15 +1,15 @@
 from app import db
+from app.lib import util
 
 class User(db.Model):
     __tablename__ = "users"
 
     id = db.Column(db.Integer, primary_key=True)
     avatar_url = db.Column(db.Text())
-    username = db.Column(db.Text())
     email = db.Column(db.Text())
     first_name = db.Column(db.Text())
     last_name = db.Column(db.Text())
-
+    username = db.Column(db.Text())
 
 class Message(db.Model):
     __tablename__ = "messages"
@@ -20,8 +20,15 @@ class Message(db.Model):
     label = db.Column(db.Text())  # "chats"
     message_id = db.Column(db.Text(), unique=True)
     sender_user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
-    timestamp = db.Column(db.Text(), index=True) # milliseconds
+    timestamp = db.Column(db.Text(), index=True)  # milliseconds
     thread_id = db.Column(db.Text())
+
+    def to_api_dict(self):
+        return dict(
+            _id=self.id,
+            sender_user_id=self.sender_user_id,
+            timestamp=self.timestamp,
+        )
 
 class Token(db.Model):
     __tablename__ = "tokens"


### PR DESCRIPTION
Adds /api/messages to get message objects. you can add query parameters `after=mm/dd/yy` and `limit=number` to specify the max amount of messages to get back.

A few concerns:
- There's no default limit for how many results to return, so the response will be SLOW if you don't provide any parameters (~30 seconds for me locally right now to return ALL messages)
- `to_api_dict` is providing the bare minimum for fields you need to populate the github widget... as soon as you start adding more data to the response it slows down quite a bit. If I include all the fields I want to, that response time goes to ~2 mins 😞 

An option could be to add caching on expected queries? We know what the widget will be looking for.. 

